### PR TITLE
Add optional support for try blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 0.1.1
+
+  - Fix a typo in the front page documentation.
+
+# 0.1
+
+  - Initial revision.


### PR DESCRIPTION
See issue #1

Adding support for try block when the try-trait feature is enabled would be useful for several use cases. This allows the macro to be used without needing to abstract a piece of code into a separate function that returns an Option or Result. Added some more tests to ensure try block behavior was as expected.

Added a second commit on here that adds a feature flag (disabled by default) to provide a `verify!` macro. While I'm not positive that I currently have a use case myself for it, it seemed like something that might be used by someone in the future. That said, I can remove that commit if desired.

The main downside here is that try blocks often have issues with automatic type detection, so the tests demonstrate that type annotations are needed. This shouldn't affect the existing function use-case, though, because they already state their return types.

I have not bumped the version. I imagine this would be a bump in the minor version, but wanted to double check with you first. I can either bump prior to merging or I can let you handle it.